### PR TITLE
Fix script workspace temp dir on Windows

### DIFF
--- a/app/run_script.py
+++ b/app/run_script.py
@@ -94,7 +94,7 @@ def run_repo_script(
 
     session_id = uuid.uuid4().hex[:12]
     session_dir = _session_plot_dir(session_id)
-    workdir = Path(tempfile.mkdtemp(prefix="sess-", dir="/tmp"))
+    workdir = Path(tempfile.mkdtemp(prefix="sess-"))
 
     cmd = ["python", str(script_path), *map(str, args)]
     proc = subprocess.run(


### PR DESCRIPTION
## Summary
- create script workspaces in the platform default temp directory instead of /tmp
- avoid Windows path errors so csvViewer.py and other scripts can run

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e46f931148832a8cc426cc73bf006e